### PR TITLE
Mountpoint property on ZFSSnapshot

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2583,7 +2583,16 @@ cdef class ZFSSnapshot(ZFSObject):
 
             nvl = NVList(<uintptr_t>ptr)
             return dict(nvl)
+        
+    property mountpoint:
+        def __get__(self):
+            cdef char *mntpt
+            if libzfs.zfs_is_mounted(self.handle, &mntpt) == 0:
+                return None
 
+            result = mntpt
+            free(mntpt)
+            return result
 
 cdef class ZFSBookmark(ZFSObject):
     def __getstate__(self):

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -2456,7 +2456,8 @@ cdef class ZFSSnapshot(ZFSObject):
         ret.update({
             'holds': self.holds,
             'dataset': self.parent.name,
-            'snapshot_name': self.snapshot_name
+            'snapshot_name': self.snapshot_name,
+            'mountpoint': self.mountpoint
         })
         return ret
 


### PR DESCRIPTION
Mountpoint property on ZFSSnapshot was lost in 0ce41c762ba1180b26aa26951af36d7eefabdac6, when ZFSSnapshot was no longer inheriting from ZFSDataset.
It's a valid property for snapshots.