### PR TITLE
Optionally auto-create ancestors of nested datasets

### DIFF
--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -1792,8 +1792,8 @@ cdef class ZFSPool(object):
                     self.root.handle,
                     c_name
                 )
-                if ret != 0:
-                    raise self.root.get_error()
+            if ret != 0:
+                raise self.root.get_error()
 
         with nogil:
             ret = libzfs.zfs_create(

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -1788,10 +1788,12 @@ cdef class ZFSPool(object):
 
         if create_ancestors:
             with nogil:
-                libzfs.zfs_create_ancestors(
+                ret = libzfs.zfs_create_ancestors(
                     self.root.handle,
                     c_name
                 )
+                if ret != 0:
+                    raise self.root.get_error()
 
         with nogil:
             ret = libzfs.zfs_create(

--- a/libzfs.pyx
+++ b/libzfs.pyx
@@ -1772,7 +1772,7 @@ cdef class ZFSPool(object):
         cdef uintptr_t nvl = <uintptr_t>libzfs.zpool_get_config(self.handle, NULL)
         return NVList(nvl)
 
-    def create(self, name, fsopts, fstype=DatasetType.FILESYSTEM, sparse_vol=False):
+    def create(self, name, fsopts, fstype=DatasetType.FILESYSTEM, sparse_vol=False, create_ancestors=False):
         cdef NVList cfsopts = NVList(otherdict=fsopts)
         cdef uint64_t vol_reservation
         cdef const char *c_name = name
@@ -1785,6 +1785,13 @@ cdef class ZFSPool(object):
                 cfsopts.handle)
 
             cfsopts['refreservation'] = vol_reservation
+
+        if create_ancestors:
+            with nogil:
+                libzfs.zfs_create_ancestors(
+                    self.root.handle,
+                    c_name
+                )
 
         with nogil:
             ret = libzfs.zfs_create(


### PR DESCRIPTION
Allows the creation of nested datasets including missing ancestors. 
This behavior is known as the [zfs create -p flag](https://github.com/freebsd/freebsd/blob/master/cddl/contrib/opensolaris/cmd/zfs/zfs_main.c#L688).

```
# zfs list | grep -c foo
0

Python 3.6.1 (default, Apr 17 2017, 19:51:49) 
[GCC 4.2.1 Compatible FreeBSD Clang 4.0.0 (tags/RELEASE_400/final 297347)] on freebsd11
Type "help", "copyright", "credits" or "license" for more information.
>>> import libzfs
>>> zfs = libzfs.ZFS()
>>> pool = zfs.get('tank')
>>> pool.create('tank/foo/bar', {}, libzfs.DatasetType.FILESYSTEM, 0, True)
>>>

# zfs list | grep -c foo
2

# zfs list | grep foo
tank/foo                              176K  128M     88K  /tank/foo
tank/foo/bar                           88K  128M     88K  /tank/foo/bar
```

The default remains not to auto-create ancestor datasets.